### PR TITLE
Raise HTTPNotFound when route not found

### DIFF
--- a/tomb_reflect/views.py
+++ b/tomb_reflect/views.py
@@ -1,3 +1,6 @@
+from pyramid.httpexceptions import HTTPNotFound
+
+
 class Routes(object):
     def __init__(self, request):
         self.request = request
@@ -15,6 +18,9 @@ class Routes(object):
         route_name = self.request.matchdict['route_name']
 
         route = self.route_manager.get_route(route_name)
+        if not route:
+            raise HTTPNotFound(
+                'The route with name %r could not be found' % route_name)
         view_name = self.route_manager.get_view_name(route_name)
 
         return {


### PR DESCRIPTION
```
$ http :9600/api_info/routes/XYZ_no_route_here
HTTP/1.1 404 Not Found
Content-Length: 211
Content-Type: text/html; charset=UTF-8
Date: Thu, 15 Jan 2015 22:09:40 GMT
Server: waitress

<html>
 <head>
  <title>404 Not Found</title>
 </head>
 <body>
  <h1>404 Not Found</h1>
  The resource could not be found.<br/><br/>
The route with name u'XYZ_no_route_here' could not be found


 </body>
</html>
```
