### PR TITLE
Make tests use master branch of tomb_routes

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,6 @@ mock
 pytest
 pytest-cov
 pytest-xdist
-tomb_routes
+https://github.com/tomborine/tomb_routes/archive/master.zip
 tox
 webtest


### PR DESCRIPTION
because the tests depend on https://github.com/tomborine/tomb_routes/pull/5

The other way to solve this is to [do a new release of tomb_routes to PyPI](https://github.com/tomborine/tomb_routes/issues/14).
